### PR TITLE
sBt2

### DIFF
--- a/src/compute_embedding.py
+++ b/src/compute_embedding.py
@@ -4,7 +4,7 @@ import tiktoken
 import openai
 from openai.embeddings_utils import get_embedding
 
-from tokenizer import get_token_from_string 
+from tokenizer import get_token_from_string, get_string_from_tokens
 
 def embedding_from_string(string: str,
                           embedding_name: "text-embedding-ada-002",
@@ -26,8 +26,11 @@ def embedding_from_string(string: str,
         list[float]: The embedding for the string is returned as vector. In case
             of text-embedding-ada-002 as embedding model the dimension is 1536.
             If no embedding can be computed because the embedding model cannot
-            be accessed or the number of tokens for the string that an embedding
-            should be computed of is too large None is returned.
+            be accessed or max_token is larger than the maximum number of tokens
+            the embedding model supports, None is returned. If the string is 
+            too long because it is encoded to more tokens than max_token, the 
+            embedding for the string that is encoded to the first max_token
+            tokens is computed.
     """
     # Check if number of tokens is too large to for default embedding model.
     if (max_token > 8191):
@@ -35,14 +38,6 @@ def embedding_from_string(string: str,
             than the maximum number of tokens', embedding_name, 'supports, \
             which is', 8191, 'tokens.')
         return [None] 
-    # Get tokens from string to test whether number of tokens is too large for 
-    # the string.
-    tokens = get_token_from_string(string, max_token=max_token, force_cut=True,
-                                   verbose=True)
-    if (tokens is None):
-        print('WARNING: The number of tokens for', string, 'exceeds the \
-            maximum number of tokens which is', max_token,'.')
-        return [None]
 
     # Test if OPENAI_API_KEY is set as environment variable.  
     if (os.environ.get('OPENAI_API_KEY') is None):
@@ -51,6 +46,15 @@ def embedding_from_string(string: str,
             environment variable by typing: export OPENAI_API_KEY=\'your key\'\
             .')
         return [None]
+    # Get tokens from string to test whether number of tokens is too large for 
+    # the string. If the number of tokens for the string exceeds the maximum
+    # number of tokens, only the first max_token tokens are returned.
+    tokens = get_token_from_string(string, max_token=max_token, force_cut=True,
+                                   verbose=True)
+    # Get string from tokens since in case the string was too long and 
+    # the number of tokens was cut, the string is different from the original
+    # string.
+    string = get_string_from_tokens(tokens) 
     return get_embedding(string, engine=embedding_name)
    
 def main():

--- a/src/tokenizer.py
+++ b/src/tokenizer.py
@@ -10,7 +10,9 @@ def get_token_from_string(string: str,
     
     Args:
         string (str): The string of which the tokens are computed.
-        encoding_name (str): Name of the encoding model.
+        encoding_name (str): Name of the encoding model. The default encoding
+            model should always be the same as the default encoding model of
+            get_string_from_tokens.
         max_token (int): Max allowed length of the token list if force_cut is 
             set to True. 
         force_cut (bool): If True, cuts off tokens after max number of token. 
@@ -42,7 +44,9 @@ def get_token_for_chunks(chunks: list[str],
 
     Args:
         chunks (list[str]): List of strings for the computation of tokens.
-        encoding_name (str): Name of the encoding model.
+        encoding_name (str): Name of the encoding model. The default encoding
+            model should always be the same as the default encoding model of
+            get_token_from_string.
         max_token (int): Max allowed length of the token list if force_cut is 
             set to True. 
         force_cut (bool): If True, cuts off tokens after max number of token. 
@@ -62,6 +66,25 @@ def get_token_for_chunks(chunks: list[str],
                                       verbose=verbose)
         chunk_token.append(token)
     return chunk_token
+
+def get_string_from_tokens(token: list[int], 
+                           encoding_name: str = "cl100k_base") -> str:
+    """
+    Gets the string that tokens encode.
+
+    Args:
+        token (list[int]): The tokens which should be decoded to the string they
+            encode.
+        encoding_name (str): Name of the encoding model. The encoding model is 
+            also needed to decode the tokens. The default encoding model should
+            always be the same as the default encoding model of 
+            get_token_from_string.
+    
+    Returns:
+        str: The string that the tokens encode.
+    """
+    encoding = tiktoken.get_encoding(encoding_name)
+    return encoding.decode(token)
 
 def main():
     text = ["You are a big boy",

--- a/src/website.py
+++ b/src/website.py
@@ -47,8 +47,13 @@ def home():
 @app.route('/file1/<file1>/file2/<file2>') 
 def compute_similarity_of_files(file1: str, file2: str) -> str:
     """This function computes first two embeddings for the contents of two files
-    and then computes the cosine similarity of the two embeddings. The 
-    cosine similarity is returned as string in a web form. 
+    and then computes the cosine similarity of the two embeddings. If a file is 
+    too large because its content is encoded to more tokens than the maximum 
+    number of tokens for which an embedding is computed, the embedding 
+    for the files content that is encoded to the first max_token tokens is 
+    computed where max_token is the maximum number of tokens for which an 
+    embedding is computed. The cosine similarity is returned as string in a web 
+    form. 
 
     Args:
         file1 (str): This parameter is the name of the first file for which the 
@@ -65,8 +70,8 @@ def compute_similarity_of_files(file1: str, file2: str) -> str:
             contains two labels file1 and file2 and the names of the files the 
             user specified. In a textfield the cosine similarity of the content 
             of the two files is displayed. If the embedding for one of the 
-            files cannot be computed, there is a message that the file is 
-            probably too large in the textfield.     
+            files cannot be computed, there is a message that the openai api key
+            was probably not set or is not valid.     
     """
     # Test if files exist.
     if not ((path.exists(file1) and path.exists(file2))):
@@ -85,7 +90,10 @@ def compute_similarity_of_files(file1: str, file2: str) -> str:
     # Test if embeddings could be computed.
     for i in range(0,2):
         if (embeddings[i] == [None]):
-            text += files[i] + " is too large to compute an embedding for it. "
+            text += "No embedding could be computed for " + files[i] + \
+                ". Probably, the openai api key is not valid or set as an " + \
+                "environment variable. Therefore, the similarity of the " + \
+                "files cannot be computed.\n"
     if not text:  # Test if both embeddings could be computed.
         # Compute cosine similarity of both embeddings and display it.
         similarity = cosine_similarity(embeddings[0], embeddings[1])

--- a/src/website.py
+++ b/src/website.py
@@ -10,9 +10,9 @@ app = Flask(__name__)
 @app.route('/')
 def home():
     return '''<form>
-    <label for="fname">Enter first file file: </label><br>
+    <label for="fname">Enter first file name: </label><br>
     <input type="text" id="file1"><br>
-    <label for="lname">Enter second file:</label><br>
+    <label for="lname">Enter second file name:</label><br>
     <input type="text" id="file2"><br><br>
 
     <button onclick="myFunction()"> Compute similarity of the files content\
@@ -44,8 +44,8 @@ def home():
 
     </form>'''
 
-@app.route('/file1/<file1>/file2/<file2>')
-def compute_similarity_of_files(file1: str, file2: str):
+@app.route('/file1/<file1>/file2/<file2>') 
+def compute_similarity_of_files(file1: str, file2: str) -> str:
     """This function computes first two embeddings for the contents of two files
     and then computes the cosine similarity of the two embeddings. The 
     cosine similarity is returned as string in a web form. 
@@ -53,20 +53,24 @@ def compute_similarity_of_files(file1: str, file2: str):
     Args:
         file1 (str): This parameter is the name of the first file for which the 
             cosine similarity of its content with the content of the second 
-            file is computed.
+            file is computed. The file should be in the same directory as this
+            program.
         file2 (str): This parameter is the name of the second file for which 
             the cosine similarity of its content with the content of the first
-            file is computed.
+            file is computed. The file should be in the same directory as this
+            program.
 
-    Returns: A web form is returned that contains two labels file1 and file2 
-        and the names of the files the user specified. In a textfield the 
-        cosine similarity of the content of the two files is displayed. If the
-        embedding for one of the files cannot be computed, there is a message
-        that the file is probably too large in the textfield.     
+    Returns: 
+        str: A string is returned that contains html code for a web from that
+            contains two labels file1 and file2 and the names of the files the 
+            user specified. In a textfield the cosine similarity of the content 
+            of the two files is displayed. If the embedding for one of the 
+            files cannot be computed, there is a message that the file is 
+            probably too large in the textfield.     
     """
     # Test if files exist.
     if not ((path.exists(file1) and path.exists(file2))):
-      return "<p>File does not exist</p>"
+      return "<p>At least one file does not exist on the server.</p>"
 
     files = [file1, file2]
     embeddings = []
@@ -99,4 +103,3 @@ def compute_similarity_of_files(file1: str, file2: str):
 
 if __name__ == '__main__':
     app.run()
-    

--- a/src/website.py
+++ b/src/website.py
@@ -1,5 +1,9 @@
-from flask import Flask
 from os import path
+
+from flask import Flask
+from openai.embeddings_utils import cosine_similarity
+
+from compute_embedding import embedding_from_string
 
 app = Flask(__name__)
 
@@ -11,7 +15,8 @@ def home():
   <label for="lname">Enter second file:</label><br>
   <input type="text" id="file2"><br><br>
 
-  <button onclick="myFunction()"> Read in files </button> <br><br>
+  <button onclick="myFunction()"> Compute similarity of the files content\
+      </button> <br><br>
 
   <p id="demo"> </p>
   <p id="url"> </p>
@@ -39,35 +44,59 @@ def home():
   <textarea name="file1" rows="10" cols="30">
   </textarea>
 
-  <form>
-  <textarea name="file2" rows="10" cols="30">
-  </textarea>
-
 </form>'''
 
 @app.route('/file1/<file1>/file2/<file2>')
-def input_files(file1, file2):
+def compute_similarity_of_files(file1: str, file2: str):
+    """This function computes first two embeddings for the contents of two files
+           and then computes the cosine similarity of the two embeddings. The 
+           cosine similarity is returned as string in a web form. 
 
-  if not((path.exists(file1) and path.exists(file2))):
-    return "<p>File does not exist</p>"
+      Args:
+          file1 (str): This parameter is the name of the first file for which 
+              the cosine similarity of its content with the content of the 
+              second file is computed.
+          file2 (str): This parameter is the name of the second file for which 
+              the cosine similarity of its content with the content of the first
+              file is computed.
 
-  file1input = open(file1, "r")
-  file2input = open(file2, "r")
-
-  file1text=file1input.read()
-  file2text=file2input.read()
+      Returns: 
+          
+    """
+    # Test if files exist.
+    if not((path.exists(file1) and path.exists(file2))):
+      return "<p>File does not exist</p>"
+    # Get content of files in one string each.
+    file1input = open(file1, "r")
+    file2input = open(file2, "r")
+    file1text=file1input.read()
+    file2text=file2input.read()
+    file1input.close()
+    file2input.close()
+    # Compute embeddings for both files.
+    file1_embedding = embedding_from_string(file1text, "text-embedding-ada-002")
+    file2_embedding = embedding_from_string(file2text, "text-embedding-ada-002")
+    text = ""
+    # Test if embeddings could be computed.
+    if(file1_embedding is None):
+        text += "File 1 " + file1 + " is too large to compute an embedding for \
+            it."
+    elif(file2_embedding is None):
+        text += "File 2 " + file2 + " is too large to compute an embedding for \
+            it."
+    else:
+        # Compute cosine similarity of both embeddings and dispaly it.
+        similarity = cosine_similarity(file1_embedding, file2_embedding)
+        text += "The cosine similarity between " + file1 + " and " + file2 + " \
+            is " + str(similarity) + "."
+    return '''
+          <label id="file1">file1: '''+file1+'''</label> <br>
+          <label id="file2">file2: '''+file2+'''</label> <br>
   
-  return '''
-  <label id="file1">file1: '''+file1+'''</label> <br>
-  <label id="file2">file2: '''+file2+'''</label> <br>
-  
-  <form>
-  <textarea id="file1content" name="file1" rows="10" cols="30">'''+file1text+'''</textarea>
+          <form>
+          <textarea id="file1content" name="file1" rows="10" cols="30">'''+text+'''</textarea>
 
-  <textarea id="file2content" name="file2" rows="10" cols="30">'''+file2text+'''</textarea>
-
-</form>
-'''
+          </form>'''
 
 if __name__ == '__main__':
     app.run()

--- a/src/website.py
+++ b/src/website.py
@@ -1,0 +1,73 @@
+from flask import Flask
+from os import path
+
+app = Flask(__name__)
+
+@app.route('/')
+def home():
+    return '''<form>
+  <label for="fname">Enter first file file: </label><br>
+  <input type="text" id="file1"><br>
+  <label for="lname">Enter second file:</label><br>
+  <input type="text" id="file2"><br><br>
+
+  <button onclick="myFunction()"> Read in files </button> <br><br>
+
+  <p id="demo"> </p>
+  <p id="url"> </p>
+
+  <script>
+    function myFunction() {
+      let f1 = document.getElementById("file1").value;
+      let f2 = document.getElementById("file2").value;
+      let actualUrl = window.location.href;
+
+      document.getElementById("url").innerHTML="";
+
+      if(!f1 || !f2){
+        document.getElementById("demo").innerHTML="";
+        alert("The file name can not be empty!");
+
+      }
+      else {
+        window.open(actualUrl+"/file1/"+f1+"/file2/"+f2);
+        }
+    }
+  </script>
+
+  <form>
+  <textarea name="file1" rows="10" cols="30">
+  </textarea>
+
+  <form>
+  <textarea name="file2" rows="10" cols="30">
+  </textarea>
+
+</form>'''
+
+@app.route('/file1/<file1>/file2/<file2>')
+def input_files(file1, file2):
+
+  if not((path.exists(file1) and path.exists(file2))):
+    return "<p>File does not exist</p>"
+
+  file1input = open(file1, "r")
+  file2input = open(file2, "r")
+
+  file1text=file1input.read()
+  file2text=file2input.read()
+  
+  return '''
+  <label id="file1">file1: '''+file1+'''</label> <br>
+  <label id="file2">file2: '''+file2+'''</label> <br>
+  
+  <form>
+  <textarea id="file1content" name="file1" rows="10" cols="30">'''+file1text+'''</textarea>
+
+  <textarea id="file2content" name="file2" rows="10" cols="30">'''+file2text+'''</textarea>
+
+</form>
+'''
+
+if __name__ == '__main__':
+    app.run()

--- a/src/website.py
+++ b/src/website.py
@@ -64,8 +64,9 @@ def compute_similarity_of_files(file1: str, file2: str):
           
     """
     # Test if files exist.
-    if not((path.exists(file1) and path.exists(file2))):
+    if not ((path.exists(file1) and path.exists(file2))):
       return "<p>File does not exist</p>"
+
     # Get content of files in one string each.
     file1input = open(file1, "r")
     file2input = open(file2, "r")
@@ -73,15 +74,16 @@ def compute_similarity_of_files(file1: str, file2: str):
     file2text=file2input.read()
     file1input.close()
     file2input.close()
+    
     # Compute embeddings for both files.
     file1_embedding = embedding_from_string(file1text, "text-embedding-ada-002")
     file2_embedding = embedding_from_string(file2text, "text-embedding-ada-002")
     text = ""
     # Test if embeddings could be computed.
-    if(file1_embedding is None):
+    if (file1_embedding is None):
         text += "File 1 " + file1 + " is too large to compute an embedding for \
             it."
-    elif(file2_embedding is None):
+    elif (file2_embedding is None):
         text += "File 2 " + file2 + " is too large to compute an embedding for \
             it."
     else:

--- a/src/website.py
+++ b/src/website.py
@@ -99,3 +99,4 @@ def compute_similarity_of_files(file1: str, file2: str):
 
 if __name__ == '__main__':
     app.run()
+    


### PR DESCRIPTION
In website.py the method input_files was changed to compute_similarities_of_files that computes the cosine similarity of two files a user specified in a web form. The cosine similarity is returned in a textfield of the web form.

Problem: If one of the computed embeddings is None, the cosine similarity cannot be computed. Therefore there is a message in the textfield that the file is probably too large to compute an embedding of it. But if the user did not set the openai api key as environment variable, the method to compute the embedding also returns None. At the moment the string in the textfield just says that the file is probably too large which is not necessarily the case if the key is not set, but you get a message in terminal that the key has to be set as environment variable. Should it be added to the displayed text in the textfield that the openai api key may not be set as environment variable?